### PR TITLE
Fix Telegram welcome message markdown escaping

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,6 +12,7 @@ from telegram.ext import (
 )
 from telegram.constants import ParseMode
 from telegram.error import TelegramError
+from telegram.helpers import escape_markdown
 from dotenv import load_dotenv
 import pandas as pd
 
@@ -575,7 +576,8 @@ async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     log_user_action(user.id, user.username, "/start")
-    args = update.message.text.split()
+    message_text = update.message.text if update.message and update.message.text else ""
+    args = message_text.split()
     bot_username = (await context.bot.get_me()).username
     ref_link = f"https://t.me/{bot_username}?start={user.id}"
     context.user_data['ref_link'] = ref_link
@@ -585,9 +587,12 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
             REFERALS.setdefault(str(referrer_id), []).append(user.id)
             save_json(REFERRALS_FILE, REFERALS)
             await context.bot.send_message(referrer_id, f"🎉 Новый реферал: {user.first_name}")
+    display_name = user.first_name or user.full_name or "друг"
+    safe_name = escape_markdown(display_name, version=1)
+    safe_ref_link = escape_markdown(ref_link, version=1)
     welcome = (
-        f"👋 Добро пожаловать, {user.first_name}! Работаем со всеми дисциплинами, кроме технических (чертежи)."
-        f" Уже 5000+ клиентов и 10% скидка на первый заказ 🔥\nПоделитесь ссылкой для бонусов: {ref_link}"
+        f"👋 Добро пожаловать, {safe_name}! Работаем со всеми дисциплинами, кроме технических (чертежи)."
+        f" Уже 5000+ клиентов и 10% скидка на первый заказ 🔥\nПоделитесь ссылкой для бонусов: {safe_ref_link}"
     )
     return await main_menu(update, context, welcome)
 


### PR DESCRIPTION
## Summary
- escape Markdown-sensitive characters in the /start welcome message so deep-link referrals and user names no longer break the markup
- guard against missing command text before splitting arguments

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c9fc1dfbc8832f89ae3700b48d47df

## Сводка от Sourcery

Очистка приветственного сообщения `/start` путем экранирования символов, чувствительных к Markdown, и добавление защиты от отсутствия текста сообщения при разборе аргументов

Исправления ошибок:
- Экранирование символов, чувствительных к Markdown, в приветственном сообщении для предотвращения сбоев разметки
- Защита от отсутствия текста сообщения перед разделением аргументов команды

Улучшения:
- Предоставление запасного отображаемого имени, если `user.first_name` или `full_name` недоступны

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize the /start welcome message by escaping Markdown-sensitive characters and add a guard against missing message text when parsing arguments

Bug Fixes:
- Escape markdown-sensitive characters in the welcome message to prevent markup breaks
- Guard against missing message text before splitting command arguments

Enhancements:
- Provide a fallback display name when user.first_name or full_name is unavailable

</details>